### PR TITLE
Fix check modern

### DIFF
--- a/check-modern-l10n.sh
+++ b/check-modern-l10n.sh
@@ -4,7 +4,6 @@
 # TODO: Add usage()
 
 #set -x
-exec 2>&-
 
 # Coloured logging
 info() {
@@ -41,6 +40,10 @@ SITE1_USER="ec2-user"
 SITE2_USER="vcs2vcs"
 
 var_check
+
+# stderr messes up output, close it, now that we're done with our own
+# message
+exec 2>&-
 
 # Assumes l10n occurs in name
 for dir in $(ssh -t ec2-user@$SITE1_IP "sudo ls $SITE1 | col | grep l10n")

--- a/check-modern-l10n.sh
+++ b/check-modern-l10n.sh
@@ -1,9 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Script to quickly spot check Modern b/w AWS and production
 # expects $SITE1_IP and $SITE2_IP to be exported, or set inside the script before use.
 # TODO: Add usage()
 
 #set -x
+
+# OSX 10.10 still ships with bash v3
+[[ $BASH_VERSINFO -ge 4 ]] || {
+    echo "bash version 4 needed, you have $BASH_VERSINFO"
+    exit 1
+} 1>&2
 
 # Coloured logging
 info() {


### PR DESCRIPTION
Address 2 issues:
- error output suppressed too soon
- osx 10.10 ships with bash 3
